### PR TITLE
Attribution source for TWDLog(fmt, …)

### DIFF
--- a/Source/Other/TWiOSReverseAuthExample-Prefix.pch
+++ b/Source/Other/TWiOSReverseAuthExample-Prefix.pch
@@ -18,7 +18,8 @@
 #endif
 
 //
-// I use a variation of these logging methods in most projects. If anyone knows the original author, please let me know so I can attribute.
+// I use a variation of these logging methods in most projects.
+// Based on http://stackoverflow.com/a/969291/48062
 //
 #ifdef DEBUG
 #   define TWDLog(fmt, ...) NSLog((@"\n%s\n" fmt), __PRETTY_FUNCTION__, ##__VA_ARGS__)


### PR DESCRIPTION
Source from http://stackoverflow.com/questions/969130/how-to-print-out-the-method-name-and-line-number-and-conditionally-disable-nslog
